### PR TITLE
Add assessment, progress, challenge and reward APIs with front-end integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# website-AHELP
+# AHELP Website
+
+This project serves the AHELP wellness application. It uses an Express server with a SQLite database and static front-end files.
+
+## API Endpoints
+
+- `POST /api/assessments` – store a user's health assessment.
+- `GET /api/progress?user_id={id}` – retrieve weekly minutes and monthly steps for charts.
+- `POST /api/progress` – update progress arrays.
+- `GET /api/challenges?user_id={id}` – list saved challenges.
+- `POST /api/challenges` – create a challenge entry.
+- `GET /api/rewards?user_id={id}` – fetch reward history and current point balance.
+- `POST /api/rewards` – record points earned or redeemed.
+
+Run the server with:
+
+```sh
+npm start
+```

--- a/improved-website-v14/challenges.html
+++ b/improved-website-v14/challenges.html
@@ -114,61 +114,8 @@
 
     <!-- Challenges section -->
     <section class="py-12">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            <!-- Card 1 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Step-Up Challenge</h2>
-                <p class="text-gray-600 mb-4">Hit 50,000 steps this week to earn bonus points.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-purple-500 h-full rounded-full" style="width: 60%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">60% complete</p>
-            </div>
-            <!-- Card 2 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Hydration Hero</h2>
-                <p class="text-gray-600 mb-4">Drink eight glasses of water daily for 7 days.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-orange-400 h-full rounded-full" style="width: 40%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">40% complete</p>
-            </div>
-            <!-- Card 3 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Mindful Minutes</h2>
-                <p class="text-gray-600 mb-4">Meditate for 15 minutes each day.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-green-400 h-full rounded-full" style="width: 80%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">80% complete</p>
-            </div>
-            <!-- Card 4 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Fruit & Veggie Feast</h2>
-                <p class="text-gray-600 mb-4">Eat five servings of fruits/vegetables daily.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-yellow-400 h-full rounded-full" style="width: 25%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">25% complete</p>
-            </div>
-            <!-- Card 5 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Sleep Soundly</h2>
-                <p class="text-gray-600 mb-4">Get 7–8 hours of sleep for a full week.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-blue-400 h-full rounded-full" style="width: 50%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">50% complete</p>
-            </div>
-            <!-- Card 6 -->
-            <div class="bg-white p-6 rounded-lg shadow-md">
-                <h2 class="text-xl font-semibold mb-2">Sugar-Free Sprint</h2>
-                <p class="text-gray-600 mb-4">Avoid processed sugar for 5 days.</p>
-                <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
-                    <div class="bg-red-400 h-full rounded-full" style="width: 10%;"></div>
-                </div>
-                <p class="text-sm text-gray-500">10% complete</p>
-            </div>
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div id="challenges-container" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
         </div>
     </section>
 
@@ -208,6 +155,34 @@
         document.getElementById('mobile-btn').addEventListener('click', () => {
             document.getElementById('mobile-menu').classList.toggle('hidden');
         });
+    </script>
+    <!-- Load challenges from API -->
+    <script>
+        async function loadChallenges() {
+            const userId = localStorage.getItem('ahelpUserId') || 1;
+            try {
+                const res = await fetch(`/api/challenges?user_id=${userId}`);
+                if (!res.ok) return;
+                const data = await res.json();
+                const container = document.getElementById('challenges-container');
+                data.forEach(ch => {
+                    const percent = ch.goal ? Math.min(100, Math.floor((ch.progress / ch.goal) * 100)) : 0;
+                    const card = document.createElement('div');
+                    card.className = 'bg-white p-6 rounded-lg shadow-md';
+                    card.innerHTML = `
+                        <h2 class="text-xl font-semibold mb-2">${ch.title}</h2>
+                        <p class="text-gray-600 mb-4">${ch.description || ''}</p>
+                        <div class="w-full bg-gray-200 h-4 rounded-full mb-3">
+                            <div class="bg-purple-500 h-full rounded-full" style="width: ${percent}%;"></div>
+                        </div>
+                        <p class="text-sm text-gray-500">${percent}% complete</p>`;
+                    container.appendChild(card);
+                });
+            } catch (e) {
+                console.error('Failed to load challenges', e);
+            }
+        }
+        loadChallenges();
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>

--- a/improved-website-v14/health-assessment.html
+++ b/improved-website-v14/health-assessment.html
@@ -300,6 +300,7 @@
                         const data = await res.json();
                         localStorage.setItem('authToken', data.token);
                         localStorage.setItem('ahelpUserName', data.user.name || name);
+                        localStorage.setItem('ahelpUserId', data.user.id);
                     }
                 } catch (err) {
                     console.error('Registration failed', err);
@@ -393,6 +394,33 @@
                 localStorage.setItem('ahelpHraDate', new Date().toISOString());
             } catch (err) {
                 console.error('Could not store recommendations in localStorage:', err);
+            }
+
+            // Persist assessment to backend
+            try {
+                const userId = localStorage.getItem('ahelpUserId');
+                await fetch('/api/assessments', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        user_id: userId,
+                        data: {
+                            exercise,
+                            fruitsVeg,
+                            water,
+                            tobacco,
+                            alcohol,
+                            sleep,
+                            stress,
+                            checkup,
+                            chronic,
+                            chronicDetails,
+                            recommendations
+                        }
+                    })
+                });
+            } catch (err) {
+                console.error('Assessment save failed', err);
             }
             // Show results section
             document.getElementById('results').classList.remove('hidden');

--- a/improved-website-v14/login.html
+++ b/improved-website-v14/login.html
@@ -183,6 +183,7 @@
                 localStorage.setItem('authToken', data.token);
                 const name = data.user.name || email.split('@')[0];
                 localStorage.setItem('ahelpUserName', name);
+                localStorage.setItem('ahelpUserId', data.user.id);
                 window.location.href = 'dashboard.html';
             } catch (err) {
                 alert(err.message);
@@ -206,6 +207,7 @@
                 const data = await res.json();
                 localStorage.setItem('authToken', data.token);
                 localStorage.setItem('ahelpUserName', data.user.name || firstName);
+                localStorage.setItem('ahelpUserId', data.user.id);
                 window.location.href = 'dashboard.html';
             } catch (err) {
                 alert(err.message);

--- a/improved-website-v14/progress.html
+++ b/improved-website-v14/progress.html
@@ -181,83 +181,102 @@
             menu.classList.toggle('hidden');
         });
         
-        // Data for the weekly activity chart
         const weeklyCtx = document.getElementById('weeklyChart').getContext('2d');
-        const weeklyChart = new Chart(weeklyCtx, {
-            type: 'bar',
-            data: {
-                labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-                datasets: [{
-                    label: 'Minutes Active',
-                    data: [30, 45, 60, 35, 50, 70, 55],
-                    backgroundColor: 'rgba(168, 85, 247, 0.5)',
-                    borderColor: 'rgba(168, 85, 247, 1)',
-                    borderWidth: 1,
-                    borderRadius: 6
-                }]
-            },
-            options: {
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        title: {
-                            display: true,
-                            text: 'Minutes'
-                        }
-                    },
-                    x: {
-                        title: {
-                            display: true,
-                            text: 'Day of Week'
-                        }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    title: { display: false }
-                }
-            }
-        });
-        
-        // Data for the monthly steps chart
         const monthlyCtx = document.getElementById('monthlyChart').getContext('2d');
-        const monthlyChart = new Chart(monthlyCtx, {
-            type: 'line',
-            data: {
-                labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4'],
-                datasets: [{
-                    label: 'Steps',
-                    data: [20000, 24000, 22000, 26000],
-                    backgroundColor: 'rgba(251, 146, 60, 0.5)',
-                    borderColor: 'rgba(251, 146, 60, 1)',
-                    tension: 0.4,
-                    fill: true,
-                    pointRadius: 4,
-                    pointBackgroundColor: 'rgba(251, 146, 60, 1)'
-                }]
-            },
-            options: {
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        title: {
-                            display: true,
-                            text: 'Steps'
+        const weeklyLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+        const monthlyLabels = ['Week 1', 'Week 2', 'Week 3', 'Week 4'];
+
+        async function loadProgress() {
+            const userId = localStorage.getItem('ahelpUserId') || 1;
+            let weekly = [0, 0, 0, 0, 0, 0, 0];
+            let monthly = [0, 0, 0, 0];
+            try {
+                const res = await fetch(`/api/progress?user_id=${userId}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    if (data.weekly && data.weekly.length) weekly = data.weekly;
+                    if (data.monthly && data.monthly.length) monthly = data.monthly;
+                }
+            } catch (e) {
+                console.error('Failed to load progress', e);
+            }
+
+            new Chart(weeklyCtx, {
+                type: 'bar',
+                data: {
+                    labels: weeklyLabels,
+                    datasets: [{
+                        label: 'Minutes Active',
+                        data: weekly,
+                        backgroundColor: 'rgba(168, 85, 247, 0.5)',
+                        borderColor: 'rgba(168, 85, 247, 1)',
+                        borderWidth: 1,
+                        borderRadius: 6
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: 'Minutes'
+                            }
+                        },
+                        x: {
+                            title: {
+                                display: true,
+                                text: 'Day of Week'
+                            }
                         }
                     },
-                    x: {
-                        title: {
-                            display: true,
-                            text: 'Week of Month'
-                        }
+                    plugins: {
+                        legend: { display: false },
+                        title: { display: false }
                     }
-                },
-                plugins: {
-                    legend: { display: false },
-                    title: { display: false }
                 }
-            }
-        });
+            });
+
+            new Chart(monthlyCtx, {
+                type: 'line',
+                data: {
+                    labels: monthlyLabels,
+                    datasets: [{
+                        label: 'Steps',
+                        data: monthly,
+                        backgroundColor: 'rgba(251, 146, 60, 0.5)',
+                        borderColor: 'rgba(251, 146, 60, 1)',
+                        tension: 0.4,
+                        fill: true,
+                        pointRadius: 4,
+                        pointBackgroundColor: 'rgba(251, 146, 60, 1)'
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: 'Steps'
+                            }
+                        },
+                        x: {
+                            title: {
+                                display: true,
+                                text: 'Week of Month'
+                            }
+                        }
+                    },
+                    plugins: {
+                        legend: { display: false },
+                        title: { display: false }
+                    }
+                }
+            });
+        }
+
+        loadProgress();
     </script>
     <!-- Back to Top Button -->
     <button id="back-to-top" class="hidden fixed bottom-6 right-6 p-3 rounded-full bg-purple-500 text-white shadow-lg" aria-label="Back to top">↑</button>

--- a/improved-website-v14/redeem.html
+++ b/improved-website-v14/redeem.html
@@ -176,37 +176,41 @@
             document.getElementById('mobile-menu').classList.toggle('hidden');
         });
 
-        // Load points from localStorage or set default
-        let points = parseInt(localStorage.getItem('userPoints') || '0');
-        document.getElementById('points-balance').textContent = points;
+        // Load points from backend
+        let points = 0;
+        const userId = localStorage.getItem('ahelpUserId') || 1;
+        async function loadPoints() {
+            try {
+                const res = await fetch(`/api/rewards?user_id=${userId}`);
+                if (res.ok) {
+                    const data = await res.json();
+                    points = data.points;
+                    document.getElementById('points-balance').textContent = points;
+                }
+            } catch (e) {
+                console.error('Failed to load points', e);
+            }
+        }
+        loadPoints();
 
         // Redeem button click handler
         document.querySelectorAll('.redeem-btn').forEach(btn => {
-            btn.addEventListener('click', () => {
+            btn.addEventListener('click', async () => {
                 const cost = parseInt(btn.getAttribute('data-cost'));
                 if (points >= cost) {
-                    points -= cost;
-                    localStorage.setItem('userPoints', points);
-                    document.getElementById('points-balance').textContent = points;
-                    // Determine reward name based on cost
-                    let rewardName;
-                    if (cost === 250) rewardName = 'Yoga Mat';
-                    else if (cost === 500) rewardName = 'Fitness Tracker';
-                    else if (cost === 750) rewardName = 'Gym Membership';
-                    // Record redemption in analytics log
+                    const title = btn.parentElement.querySelector('h3').textContent;
                     try {
-                        const log = JSON.parse(localStorage.getItem('redemptionLog')) || [];
-                        log.push({
-                            user: localStorage.getItem('userEmail') || 'guest@ahelp.com',
-                            reward: rewardName,
-                            cost: cost,
-                            date: new Date().toISOString()
+                        await fetch('/api/rewards', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ user_id: userId, title, points: -cost })
                         });
-                        localStorage.setItem('redemptionLog', JSON.stringify(log));
+                        points -= cost;
+                        document.getElementById('points-balance').textContent = points;
+                        alert('Redemption successful!');
                     } catch (e) {
-                        // ignore JSON errors
+                        console.error('Redemption failed', e);
                     }
-                    alert('Redemption successful!');
                 } else {
                     alert('Not enough points to redeem this reward.');
                 }


### PR DESCRIPTION
## Summary
- create SQLite tables and Express endpoints for assessments, progress, challenges and rewards
- wire health assessment, progress chart, challenges and rewards pages to backend APIs
- document available API endpoints in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6894a4cd6ea08320b86f8b4d28c22563