### PR TITLE
Add input validation and security hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
+        "csurf": "^1.11.0",
         "ejs": "^3.1.10",
         "express": "^4.18.2",
+        "helmet": "^8.1.0",
+        "joi": "^18.0.0",
         "jsonwebtoken": "^9.0.2",
-        "sqlite3": "^5.1.6"
+        "sqlite3": "^5.1.6",
+        "xss": "^1.0.15"
       }
     },
     "node_modules/@gar/promisify": {
@@ -21,6 +26,54 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.2.tgz",
+      "integrity": "sha512-1jkwm1WY9VIb6WhdANRmWDkXQUcIRpxqZpSdS+HD9vhoVL3zwoFvP8doQNEgT6k3VST0Ewu50wZnXIceRYp5tw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
@@ -47,6 +100,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -401,6 +460,12 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -445,11 +510,127 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/csrf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+      "license": "MIT",
+      "dependencies": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
+    "node_modules/csurf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
+      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "csrf": "3.1.0",
+        "http-errors": "~1.7.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/csurf/node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/csurf/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csurf/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -970,6 +1151,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -1227,6 +1417,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/joi": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.0.tgz",
+      "integrity": "sha512-fpbpXN/TD04Xz1/cCXzUR3ghDkhyiHjbzTILx3wNyKXIzQJ55uYAkUGWwhX72uHge/6MdFA/kp1ZUh35DlYmaA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/jsbn": {
@@ -1846,6 +2054,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1925,6 +2142,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rndm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2389,6 +2612,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -2412,6 +2644,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unique-filename": {
@@ -2498,6 +2742,22 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.7",
+    "csurf": "^1.11.0",
     "ejs": "^3.1.10",
     "express": "^4.18.2",
+    "helmet": "^8.1.0",
+    "joi": "^18.0.0",
     "jsonwebtoken": "^9.0.2",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "xss": "^1.0.15"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,15 +3,120 @@ const sqlite3 = require('sqlite3').verbose();
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const path = require('path');
+const fs = require('fs');
+const https = require('https');
+const helmet = require('helmet');
+const cookieParser = require('cookie-parser');
+const csrf = require('csurf');
+const Joi = require('joi');
+const xss = require('xss');
 
 const app = express();
 const db = new sqlite3.Database('users.db');
 const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret';
 
+app.use(helmet());
 app.use(express.json());
+app.use(cookieParser());
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(express.static(path.join(__dirname, 'improved-website-v14')));
+app.use(csrf({ cookie: true }));
+app.use((req, res, next) => {
+  res.cookie('XSRF-TOKEN', req.csrfToken(), {
+    httpOnly: false,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production'
+  });
+  next();
+});
+
+function sanitizeInput(input) {
+  if (typeof input === 'string') {
+    return xss(input);
+  }
+  if (typeof input === 'object' && input !== null) {
+    const sanitized = {};
+    for (const key in input) {
+      sanitized[key] = sanitizeInput(input[key]);
+    }
+    return sanitized;
+  }
+  return input;
+}
+
+function validate(schema) {
+  return (req, res, next) => {
+    const sanitized = sanitizeInput(req.body);
+    const { error, value } = schema.validate(sanitized);
+    if (error) {
+      return res.status(400).json({ error: error.details[0].message });
+    }
+    req.body = value;
+    next();
+  };
+}
+
+const registerSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().min(6).required(),
+  name: Joi.string().allow('')
+});
+
+const loginSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().required()
+});
+
+const assessmentSchema = Joi.object({
+  user_id: Joi.number().integer().required(),
+  data: Joi.object().required()
+});
+
+const progressSchema = Joi.object({
+  user_id: Joi.number().integer().required(),
+  weekly: Joi.array().items(Joi.number()).optional(),
+  monthly: Joi.array().items(Joi.number()).optional()
+});
+
+const challengeSchema = Joi.object({
+  user_id: Joi.number().integer().required(),
+  title: Joi.string().required(),
+  description: Joi.string().allow('').optional(),
+  progress: Joi.number().integer().min(0).optional(),
+  goal: Joi.number().integer().min(0).optional()
+});
+
+const rewardSchema = Joi.object({
+  user_id: Joi.number().integer().required(),
+  title: Joi.string().required(),
+  points: Joi.number().integer().required()
+});
+
+const updateUserSchema = Joi.object({
+  name: Joi.string().allow('', null),
+  is_admin: Joi.number().integer().valid(0, 1).optional()
+});
+
+const challengeUpdateSchema = Joi.object({
+  title: Joi.string().optional(),
+  description: Joi.string().allow('').optional(),
+  progress: Joi.number().integer().min(0).optional(),
+  goal: Joi.number().integer().min(0).optional(),
+  user_id: Joi.number().integer().optional()
+});
+
+const rewardInventorySchema = Joi.object({
+  title: Joi.string().required(),
+  points: Joi.number().integer().required(),
+  quantity: Joi.number().integer().optional()
+});
+
+const rewardInventoryUpdateSchema = Joi.object({
+  title: Joi.string().optional(),
+  points: Joi.number().integer().optional(),
+  quantity: Joi.number().integer().optional()
+});
 
 app.get('/', (req, res) => {
   res.render('index');
@@ -88,7 +193,7 @@ db.run(createInventory);
 
 function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const token = req.cookies.token || (authHeader && authHeader.split(' ')[1]);
   if (!token) {
     return res.status(401).json({ error: 'Missing token' });
   }
@@ -111,11 +216,8 @@ function requireAdmin(req, res, next) {
 }
 
 // Register endpoint
-app.post('/api/auth/register', (req, res) => {
+app.post('/api/auth/register', validate(registerSchema), (req, res) => {
   const { email, password, name } = req.body;
-  if (!email || !password) {
-    return res.status(400).json({ error: 'Email and password required' });
-  }
   const hashed = bcrypt.hashSync(password, 10);
   const stmt = `INSERT INTO users (email, name, password, is_admin) VALUES (?, ?, ?, 0)`;
   db.run(stmt, [email, name || '', hashed], function (err) {
@@ -127,16 +229,19 @@ app.post('/api/auth/register', (req, res) => {
     }
     const user = { id: this.lastID, email, name: name || '', is_admin: 0 };
     const token = jwt.sign(user, JWT_SECRET, { expiresIn: '1h' });
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 3600000
+    });
     res.json({ token, user });
   });
 });
 
 // Login endpoint
-app.post('/api/auth/login', (req, res) => {
+app.post('/api/auth/login', validate(loginSchema), (req, res) => {
   const { email, password } = req.body;
-  if (!email || !password) {
-    return res.status(400).json({ error: 'Email and password required' });
-  }
   const query = `SELECT * FROM users WHERE email = ?`;
   db.get(query, [email], (err, row) => {
     if (err) {
@@ -156,16 +261,19 @@ app.post('/api/auth/login', (req, res) => {
       is_admin: row.is_admin || 0,
     };
     const token = jwt.sign(user, JWT_SECRET, { expiresIn: '1h' });
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+      maxAge: 3600000
+    });
     res.json({ token, user });
   });
 });
 
 // --- Assessments ---
-app.post('/api/assessments', (req, res) => {
+app.post('/api/assessments', validate(assessmentSchema), (req, res) => {
   const { user_id, data } = req.body;
-  if (!user_id || !data) {
-    return res.status(400).json({ error: 'user_id and data required' });
-  }
   const stmt = `INSERT INTO assessments (user_id, data) VALUES (?, ?)`;
   db.run(stmt, [user_id, JSON.stringify(data)], function (err) {
     if (err) {
@@ -176,7 +284,7 @@ app.post('/api/assessments', (req, res) => {
 });
 
 app.get('/api/assessments', (req, res) => {
-  const userId = req.query.user_id;
+  const userId = sanitizeInput(req.query.user_id);
   const query = userId
     ? `SELECT * FROM assessments WHERE user_id = ?`
     : `SELECT * FROM assessments`;
@@ -190,11 +298,8 @@ app.get('/api/assessments', (req, res) => {
 });
 
 // --- Progress ---
-app.post('/api/progress', (req, res) => {
+app.post('/api/progress', validate(progressSchema), (req, res) => {
   const { user_id, weekly, monthly } = req.body;
-  if (!user_id) {
-    return res.status(400).json({ error: 'user_id required' });
-  }
   const stmt = `INSERT INTO progress (user_id, weekly, monthly)
                VALUES (?, ?, ?)
                ON CONFLICT(user_id) DO UPDATE SET
@@ -209,7 +314,7 @@ app.post('/api/progress', (req, res) => {
 });
 
 app.get('/api/progress', (req, res) => {
-  const userId = req.query.user_id;
+  const userId = sanitizeInput(req.query.user_id);
   if (!userId) {
     return res.status(400).json({ error: 'user_id required' });
   }
@@ -229,11 +334,8 @@ app.get('/api/progress', (req, res) => {
 });
 
 // --- Challenges ---
-app.post('/api/challenges', (req, res) => {
+app.post('/api/challenges', validate(challengeSchema), (req, res) => {
   const { user_id, title, description, progress, goal } = req.body;
-  if (!user_id || !title) {
-    return res.status(400).json({ error: 'user_id and title required' });
-  }
   const stmt = `INSERT INTO challenges (user_id, title, description, progress, goal) VALUES (?, ?, ?, ?, ?)`;
   db.run(stmt, [user_id, title, description || '', progress || 0, goal || 0], function (err) {
     if (err) {
@@ -244,7 +346,7 @@ app.post('/api/challenges', (req, res) => {
 });
 
 app.get('/api/challenges', (req, res) => {
-  const userId = req.query.user_id;
+  const userId = sanitizeInput(req.query.user_id);
   const query = userId
     ? `SELECT * FROM challenges WHERE user_id = ?`
     : `SELECT * FROM challenges`;
@@ -258,11 +360,8 @@ app.get('/api/challenges', (req, res) => {
 });
 
 // --- Rewards ---
-app.post('/api/rewards', (req, res) => {
+app.post('/api/rewards', validate(rewardSchema), (req, res) => {
   const { user_id, title, points } = req.body;
-  if (!user_id || !title || typeof points !== 'number') {
-    return res.status(400).json({ error: 'user_id, title and points required' });
-  }
   const stmt = `INSERT INTO rewards (user_id, title, points) VALUES (?, ?, ?)`;
   db.run(stmt, [user_id, title, points], function (err) {
     if (err) {
@@ -273,7 +372,7 @@ app.post('/api/rewards', (req, res) => {
 });
 
 app.get('/api/rewards', (req, res) => {
-  const userId = req.query.user_id;
+  const userId = sanitizeInput(req.query.user_id);
   if (!userId) {
     return res.status(400).json({ error: 'user_id required' });
   }
@@ -297,7 +396,7 @@ app.get('/api/admin/users', requireAdmin, (req, res) => {
   });
 });
 
-app.put('/api/admin/users/:id', requireAdmin, (req, res) => {
+app.put('/api/admin/users/:id', requireAdmin, validate(updateUserSchema), (req, res) => {
   const { name, is_admin } = req.body;
   const stmt = `UPDATE users SET name = COALESCE(?, name), is_admin = COALESCE(?, is_admin) WHERE id = ?`;
   db.run(
@@ -331,11 +430,8 @@ app.get('/api/admin/challenges', requireAdmin, (req, res) => {
   });
 });
 
-app.post('/api/admin/challenges', requireAdmin, (req, res) => {
+app.post('/api/admin/challenges', requireAdmin, validate(challengeSchema), (req, res) => {
   const { user_id, title, description, progress, goal } = req.body;
-  if (!user_id || !title) {
-    return res.status(400).json({ error: 'user_id and title required' });
-  }
   const stmt =
     `INSERT INTO challenges (user_id, title, description, progress, goal) VALUES (?, ?, ?, ?, ?)`;
   db.run(
@@ -350,7 +446,7 @@ app.post('/api/admin/challenges', requireAdmin, (req, res) => {
   );
 });
 
-app.put('/api/admin/challenges/:id', requireAdmin, (req, res) => {
+app.put('/api/admin/challenges/:id', requireAdmin, validate(challengeUpdateSchema), (req, res) => {
   const { title, description, progress, goal } = req.body;
   const stmt =
     `UPDATE challenges SET title = COALESCE(?, title), description = COALESCE(?, description), progress = COALESCE(?, progress), goal = COALESCE(?, goal) WHERE id = ?`;
@@ -385,11 +481,8 @@ app.get('/api/admin/reward-inventory', requireAdmin, (req, res) => {
   });
 });
 
-app.post('/api/admin/reward-inventory', requireAdmin, (req, res) => {
+app.post('/api/admin/reward-inventory', requireAdmin, validate(rewardInventorySchema), (req, res) => {
   const { title, points, quantity } = req.body;
-  if (!title || typeof points !== 'number') {
-    return res.status(400).json({ error: 'title and points required' });
-  }
   const stmt =
     `INSERT INTO reward_inventory (title, points, quantity) VALUES (?, ?, ?)`;
   db.run(stmt, [title, points, quantity || 0], function (err) {
@@ -400,7 +493,7 @@ app.post('/api/admin/reward-inventory', requireAdmin, (req, res) => {
   });
 });
 
-app.put('/api/admin/reward-inventory/:id', requireAdmin, (req, res) => {
+app.put('/api/admin/reward-inventory/:id', requireAdmin, validate(rewardInventoryUpdateSchema), (req, res) => {
   const { title, points, quantity } = req.body;
   const stmt =
     `UPDATE reward_inventory SET title = COALESCE(?, title), points = COALESCE(?, points), quantity = COALESCE(?, quantity) WHERE id = ?`;
@@ -426,8 +519,18 @@ app.delete('/api/admin/reward-inventory/:id', requireAdmin, (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+if (process.env.SSL_KEY && process.env.SSL_CERT) {
+  const httpsOptions = {
+    key: fs.readFileSync(process.env.SSL_KEY),
+    cert: fs.readFileSync(process.env.SSL_CERT)
+  };
+  https.createServer(httpsOptions, app).listen(PORT, () => {
+    console.log(`HTTPS server listening on port ${PORT}`);
+  });
+} else {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
 
 module.exports = app;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,6 +6,7 @@
     <title>AHELP – Empower Your Wellness Journey</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
 </head>
 <body class="text-gray-700 antialiased">
     <%- include('partials/nav') %>
@@ -56,7 +57,7 @@
                 list.innerHTML = '';
                 items.forEach(c => {
                     const li = document.createElement('li');
-                    li.textContent = c.title;
+                    li.innerHTML = DOMPurify.sanitize(c.title);
                     list.appendChild(li);
                 });
                 modal.classList.remove('hidden');

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AHELP – Login</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
 </head>
 <body class="text-gray-700 antialiased">
     <%- include('partials/nav') %>
@@ -22,11 +23,19 @@
         document.getElementById('menu-btn').addEventListener('click', () => {
             document.getElementById('mobile-menu').classList.toggle('hidden');
         });
+        const getCsrfToken = () => {
+            const token = document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='));
+            return token ? token.split('=')[1] : '';
+        };
+
         document.getElementById('login-form').addEventListener('submit', async (e) => {
             e.preventDefault();
             const res = await fetch('/api/auth/login', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': getCsrfToken()
+                },
                 body: JSON.stringify({
                     email: document.getElementById('email').value,
                     password: document.getElementById('password').value
@@ -34,7 +43,7 @@
             });
             if (res.ok) {
                 const data = await res.json();
-                alert('Logged in as ' + data.user.email);
+                alert('Logged in as ' + DOMPurify.sanitize(data.user.email));
             } else {
                 document.getElementById('login-error').textContent = 'Login failed';
                 document.getElementById('login-error').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Add Joi schemas and sanitization middleware
- Enable HTTPS with secure JWT cookies and CSRF tokens
- Sanitize template output using DOMPurify

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894a9dd23f48320a6e21efc3ff159ee