### PR TITLE
Use array data for progress chart

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -31,7 +31,7 @@
         // Load progress dynamically
         const ctx = document.getElementById('activity-chart').getContext('2d');
         fetch('/api/progress?user_id=1').then(res => res.json()).then(data => {
-            const weekly = data.weekly ? JSON.parse(data.weekly) : [0,0,0,0,0,0,0];
+            const weekly = Array.isArray(data.weekly) && data.weekly.length ? data.weekly : [0,0,0,0,0,0,0];
             new Chart(ctx, {
                 type: 'line',
                 data: {


### PR DESCRIPTION
## Summary
- Remove unnecessary JSON parsing in homepage view so progress data is treated as an array directly.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` and `curl -sS http://localhost:3000/api/progress?user_id=1`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_6894aff64b408320861783d76ef4029b