### PR TITLE
feat: improve mobile nav accessibility

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,11 +23,6 @@
     <%- include('partials/footer') %>
     <%- include('partials/modal') %>
     <script>
-        // Mobile navigation toggle
-        document.getElementById('menu-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
-
         // Load progress dynamically
         const ctx = document.getElementById('activity-chart').getContext('2d');
         fetch('/api/progress?user_id=1').then(res => res.json()).then(data => {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -20,9 +20,6 @@
     </div>
     <%- include('partials/footer') %>
     <script>
-        document.getElementById('menu-btn').addEventListener('click', () => {
-            document.getElementById('mobile-menu').classList.toggle('hidden');
-        });
         const getCsrfToken = () => {
             const token = document.cookie.split('; ').find(row => row.startsWith('XSRF-TOKEN='));
             return token ? token.split('=')[1] : '';

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -10,7 +10,7 @@
             <a href="#progress" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Activity</a>
             <a href="/login" class="text-1xl font-extrabold bg-gradient-to-r from-purple-400 to-orange-300 bg-clip-text text-transparent">Login</a>
         </div>
-        <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none">
+        <button id="menu-btn" class="md:hidden text-gray-700 focus:outline-none" aria-label="Toggle navigation" aria-expanded="false">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
             </svg>
@@ -23,4 +23,15 @@
         <a href="#progress" class="block py-2 hover:text-purple-600">Activity</a>
         <a href="/login" class="block py-2 hover:text-purple-600">Login</a>
     </div>
+    <script>
+        (function () {
+            const menuBtn = document.getElementById('menu-btn');
+            const mobileMenu = document.getElementById('mobile-menu');
+            menuBtn.addEventListener('click', () => {
+                const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
+                menuBtn.setAttribute('aria-expanded', String(!expanded));
+                mobileMenu.classList.toggle('hidden');
+            });
+        })();
+    </script>
 </nav>


### PR DESCRIPTION
## Summary
- add aria label and expandable state toggle to mobile nav button
- centralize menu toggle logic in nav partial

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx -y pa11y http://localhost:3000` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_6894aff56e608320b96e4103d74816b4