### PR TITLE
Add CSRF token handling to auth requests

### DIFF
--- a/improved-website-v14/login.html
+++ b/improved-website-v14/login.html
@@ -151,6 +151,11 @@
         const signupTab = document.getElementById('signup-tab');
         const loginForm = document.getElementById('login-form');
         const signupForm = document.getElementById('signup-form');
+
+        function getCsrfToken() {
+            const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+            return match ? decodeURIComponent(match[1]) : '';
+        }
         
         loginTab.addEventListener('click', () => {
             loginTab.classList.add('bg-white', 'shadow', 'text-gray-900');
@@ -175,7 +180,10 @@
             try {
                 const res = await fetch('/api/auth/login', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': getCsrfToken()
+                    },
                     body: JSON.stringify({ email, password })
                 });
                 if (!res.ok) throw new Error('Login failed');
@@ -200,7 +208,10 @@
             try {
                 const res = await fetch('/api/auth/register', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': getCsrfToken()
+                    },
                     body: JSON.stringify({ email, password, name })
                 });
                 if (!res.ok) throw new Error('Registration failed');


### PR DESCRIPTION
## Summary
- Read `XSRF-TOKEN` cookie in `login.html`
- Include `X-CSRF-Token` header in login and signup fetch calls

## Testing
- `curl -i -b cookies.txt -H "X-CSRF-Token: $CSRF" -H "Content-Type: application/json" -d '{"email":"user@example.com","password":"password123","name":"Test User"}' http://localhost:3000/api/auth/register`
- `curl -i -b cookies.txt -H "X-CSRF-Token: $CSRF" -H "Content-Type: application/json" -d '{"email":"user@example.com","password":"password123"}' http://localhost:3000/api/auth/login`


------
https://chatgpt.com/codex/tasks/task_e_6894aff8433c8320bf082b064f7f7e2b